### PR TITLE
apply word breaks to VAR and END_VAR keyword detection.

### DIFF
--- a/syntaxes/st.tmLanguage.json
+++ b/syntaxes/st.tmLanguage.json
@@ -217,13 +217,13 @@
 			"patterns": [
 				{
 					"comment": "Rule for OF in var declaration",
-					"begin": "\\b(?:VAR(?:_(?:INPUT|OUTPUT|IN_OUT|TEMP|GLOBAL|ACCESS|EXTERNAL))?|STRUCT|UNION|PUBLIC|PRIVATE|PROTECTED)",
+					"begin": "\\b(?:VAR(?:_(?:INPUT|OUTPUT|IN_OUT|TEMP|GLOBAL|ACCESS|EXTERNAL))?|STRUCT|UNION|PUBLIC|PRIVATE|PROTECTED)\\b",
 					"beginCaptures": {
 						"0": {
 							"name": "entity.name.type.st"
 						}
 					},
-					"end": "(?:END_(?:VAR|STRUCT|UNION))",
+					"end": "\\b(?:END_(?:VAR|STRUCT|UNION))\\b",
 					"endCaptures": {
 						"0": {
 							"name": "entity.name.type.st"


### PR DESCRIPTION
Fixes #31, applying word break requirements to the keywords to insure they are not considered a keyword if run together with other text or keywords.