### PR TITLE
Add RTAC Support

### DIFF
--- a/syntaxes/xml.codeblock.json
+++ b/syntaxes/xml.codeblock.json
@@ -8,7 +8,7 @@
     ],
     "repository": {
         "xml-code-block": {
-            "begin": "(<)(Declaration|ST)(>)\\s*",
+            "begin": "(<)(Declaration|ST|Implementation|Interface)(>)\\s*",
             "end": "\\s*(<\\/)(\\2)(>)$",
             "beginCaptures": {
                 "1": {


### PR DESCRIPTION
SEL RTAC (real time automation controller) exports its ST files as xml with the ST code in Implementaiton or Interface tags. This PR simply adds those two tags.